### PR TITLE
Fix version mismatch, add X11 tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest

--- a/src/clipboard_mcp/__init__.py
+++ b/src/clipboard_mcp/__init__.py
@@ -1,3 +1,5 @@
 """MCP server for reading content from the system clipboard."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("clipboard-mcp-server")

--- a/src/clipboard_mcp/server.py
+++ b/src/clipboard_mcp/server.py
@@ -49,7 +49,14 @@ _INSTRUCTIONS_DIR = Path(__file__).parent / "instructions"
 
 def _load_instruction(name: str) -> str:
     """Load an instruction file from the instructions/ directory."""
-    return (_INSTRUCTIONS_DIR / f"{name}.md").read_text().strip()
+    path = _INSTRUCTIONS_DIR / f"{name}.md"
+    try:
+        return path.read_text().strip()
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"Missing instruction file: {path}. "
+            "The clipboard-mcp package may be installed incorrectly."
+        ) from None
 
 
 mcp = FastMCP(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -585,6 +585,8 @@ def test_detect_backend_prefers_env_var_over_socket():
 # ---------------------------------------------------------------------------
 
 from clipboard_mcp.clipboard import (
+    _x11_read,
+    _x11_list_formats,
     _macos_read,
     _macos_list_formats,
     _UTI_TO_MIME,
@@ -696,3 +698,52 @@ async def test_windows_list_formats_passthrough_unknown():
         result = await _windows_list_formats()
 
     assert result == ["text/html", "System.String"]
+
+
+# ---------------------------------------------------------------------------
+# 10. X11 backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_x11_read_html():
+    """_x11_read calls xclip with correct target for text/html."""
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value="<b>hi</b>") as mock_run:
+        result = await _x11_read("text/html")
+
+    assert result == "<b>hi</b>"
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["xclip", "-selection", "clipboard", "-target", "text/html", "-o"]
+
+
+@pytest.mark.asyncio
+async def test_x11_read_plain():
+    """_x11_read calls xclip with correct target for text/plain."""
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value="hello") as mock_run:
+        result = await _x11_read("text/plain")
+
+    assert result == "hello"
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["xclip", "-selection", "clipboard", "-target", "text/plain", "-o"]
+
+
+@pytest.mark.asyncio
+async def test_x11_list_formats():
+    """_x11_list_formats calls xclip with TARGETS and parses output."""
+    raw_output = "text/html\ntext/plain\nimage/png\n"
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value=raw_output) as mock_run:
+        result = await _x11_list_formats()
+
+    assert result == ["text/html", "text/plain", "image/png"]
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["xclip", "-selection", "clipboard", "-target", "TARGETS", "-o"]
+
+
+@pytest.mark.asyncio
+async def test_x11_list_formats_strips_whitespace():
+    """_x11_list_formats strips whitespace and skips blank lines."""
+    raw_output = "  text/html  \n\n  text/plain  \n"
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value=raw_output):
+        result = await _x11_list_formats()
+
+    assert result == ["text/html", "text/plain"]


### PR DESCRIPTION
## Summary
- **Version single source of truth**: replaced hardcoded `__version__ = "0.1.0"` in `__init__.py` with `importlib.metadata.version()` so `pyproject.toml` is the only place the version is set (fixes the documented 0.1.0 vs 0.1.1 mismatch)
- **X11 backend tests**: added 4 tests for `_x11_read()` and `_x11_list_formats()` — was the only backend with zero test coverage
- **CI test workflow**: new `.github/workflows/test.yml` runs `uv run pytest` on push/PR to main across Python 3.11–3.13
- **Error handling**: `_load_instruction()` now raises a descriptive `RuntimeError` instead of a raw `FileNotFoundError` when instruction files are missing

## Test plan
- [x] All 87 tests pass (83 existing + 4 new X11 tests)
- [x] Verify CI workflow runs on this PR
- [x] Confirm `python -c "import clipboard_mcp; print(clipboard_mcp.__version__)"` prints `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)