### PR TITLE
v1.1.0: RTF clipboard read (Group 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented here.
 
+## [1.1.0] - 2026-03-15
+
+### Added
+- RTF clipboard read support (`text/rtf`) on macOS (via `osascript`/NSPasteboard) and Windows (via PowerShell/`DataFormats::Rtf`)
+- `clipboard_paste` Strategy 3: when HTML and plain text are both empty, attempts `text/rtf` as a fallback before checking for binary formats; RTF content is returned in a fenced code block labelled "rich text (RTF)", truncated at 50KB
+- Wayland and X11 backends already supported `text/rtf` via pass-through MIME to `wl-paste`/`xclip`
+
 ## [1.0.1] - 2026-03-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clipboard-mcp-server"
-version = "1.0.1"
+version = "1.1.0"
 description = "MCP server that reads and writes the system clipboard — tables, text, code, JSON, URLs, images, and more."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/clipboard_mcp/clipboard.py
+++ b/src/clipboard_mcp/clipboard.py
@@ -271,6 +271,18 @@ async def _macos_read(mime_type: str) -> str:
     if mime_type == "text/plain":
         return await _run(["pbpaste"], allow_empty_exit=False)
 
+    if mime_type == "text/rtf":
+        script = (
+            'use framework "AppKit"\n'
+            "set pb to current application's NSPasteboard's generalPasteboard()\n"
+            'set rtfData to pb\'s dataForType:"public.rtf"\n'
+            'if rtfData is missing value then return ""\n'
+            "set rtfString to (current application's NSString's alloc()'s "
+            "initWithData:rtfData encoding:(current application's NSUTF8StringEncoding))\n"
+            "return rtfString as text"
+        )
+        return await _run(["osascript", "-e", script], allow_empty_exit=False)
+
     # Unsupported MIME type — signal "not available" rather than returning wrong content
     return ""
 
@@ -323,6 +335,20 @@ async def _windows_read(mime_type: str) -> str:
             "-NoProfile",
             "-Command",
             "Get-Clipboard",
+        ], allow_empty_exit=False)
+
+    if mime_type == "text/rtf":
+        script = (
+            "Add-Type -AssemblyName System.Windows.Forms; "
+            "$data = [System.Windows.Forms.Clipboard]::GetData("
+            "[System.Windows.Forms.DataFormats]::Rtf); "
+            "if ($data -eq $null) { return }; $data"
+        )
+        return await _run([
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            script,
         ], allow_empty_exit=False)
 
     # Unsupported MIME type — signal "not available" rather than returning wrong content

--- a/src/clipboard_mcp/server.py
+++ b/src/clipboard_mcp/server.py
@@ -194,6 +194,20 @@ async def clipboard_paste(
     if not content:
         content = text
 
+    # Strategy 3: RTF fallback — try text/rtf when HTML and plain text are empty
+    if not content.strip():
+        try:
+            rtf = await read_clipboard("text/rtf")
+            if rtf.strip():
+                truncated = len(rtf) > _MAX_CONTENT_LEN
+                display = rtf[:_MAX_CONTENT_LEN]
+                result = f"Clipboard contains rich text (RTF):\n\n```\n{display}\n```"
+                if truncated:
+                    result += "\n\n... [truncated at 50KB]"
+                return result
+        except ClipboardError as e:
+            logger.debug("RTF clipboard read failed: %s", e)
+
     # If no text content at all, check whether the clipboard holds binary data
     if not content.strip():
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -657,8 +657,21 @@ async def test_macos_read_plain():
 @pytest.mark.asyncio
 async def test_macos_read_unsupported_returns_empty():
     """_macos_read returns empty string for unsupported MIME types."""
-    result = await _macos_read("text/rtf")
+    result = await _macos_read("text/xml")
     assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_macos_read_rtf():
+    """_macos_read uses osascript for text/rtf."""
+    rtf_content = r"{\rtf1\ansi Hello, {\b world}!}"
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value=rtf_content) as mock_run:
+        result = await _macos_read("text/rtf")
+
+    assert result == rtf_content
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "osascript"
+    assert "public.rtf" in mock_run.call_args[0][0][-1]
 
 
 @pytest.mark.asyncio
@@ -712,8 +725,21 @@ async def test_windows_read_plain():
 @pytest.mark.asyncio
 async def test_windows_read_unsupported_returns_empty():
     """_windows_read returns empty string for unsupported MIME types."""
-    result = await _windows_read("text/rtf")
+    result = await _windows_read("text/xml")
     assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_windows_read_rtf():
+    """_windows_read uses PowerShell RTF clipboard for text/rtf."""
+    rtf_content = r"{\rtf1\ansi Hello, {\b world}!}"
+    with patch("clipboard_mcp.clipboard._run", new_callable=AsyncMock, return_value=rtf_content) as mock_run:
+        result = await _windows_read("text/rtf")
+
+    assert result == rtf_content
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "powershell"
+    assert "Rtf" in cmd[-1]
 
 
 @pytest.mark.asyncio
@@ -1486,6 +1512,74 @@ async def test_paste_video_reports_binary():
     assert isinstance(result, str)
     assert "video/mp4" in result
     assert "binary data" in result
+
+
+@pytest.mark.asyncio
+async def test_paste_rtf_fallback():
+    """clipboard_paste returns RTF content when HTML and plain text are empty."""
+    rtf_content = r"{\rtf1\ansi Hello, {\b world}!}"
+
+    async def mock_read(mime_type="text/plain"):
+        if mime_type == "text/rtf":
+            return rtf_content
+        return ""
+
+    with patch("clipboard_mcp.server.read_clipboard", side_effect=mock_read):
+        with patch("clipboard_mcp.server.list_clipboard_formats", return_value=["text/rtf"]):
+            result = await clipboard_paste()
+
+    assert isinstance(result, str)
+    assert "rich text (RTF)" in result
+    assert rtf_content in result
+
+
+@pytest.mark.asyncio
+async def test_paste_rtf_truncated():
+    """clipboard_paste truncates oversized RTF at 50KB."""
+    rtf_content = r"{\rtf1\ansi " + ("x" * 60_000) + "}"
+
+    async def mock_read(mime_type="text/plain"):
+        if mime_type == "text/rtf":
+            return rtf_content
+        return ""
+
+    with patch("clipboard_mcp.server.read_clipboard", side_effect=mock_read):
+        with patch("clipboard_mcp.server.list_clipboard_formats", return_value=["text/rtf"]):
+            result = await clipboard_paste()
+
+    assert "truncated" in result
+    assert "rich text (RTF)" in result
+
+
+@pytest.mark.asyncio
+async def test_paste_rtf_skipped_when_text_present():
+    """clipboard_paste does not attempt RTF read when plain text is available."""
+    async def mock_read(mime_type="text/plain"):
+        if mime_type == "text/plain":
+            return "hello world"
+        if mime_type == "text/rtf":
+            raise AssertionError("RTF should not be read when plain text is present")
+        return ""
+
+    with patch("clipboard_mcp.server.read_clipboard", side_effect=mock_read):
+        result = await clipboard_paste()
+
+    assert "hello world" in result
+
+
+@pytest.mark.asyncio
+async def test_paste_rtf_error_falls_through():
+    """clipboard_paste falls through to binary check when RTF read raises ClipboardError."""
+    async def mock_read(mime_type="text/plain"):
+        if mime_type == "text/rtf":
+            raise ClipboardError("rtf not available")
+        return ""
+
+    with patch("clipboard_mcp.server.read_clipboard", side_effect=mock_read):
+        with patch("clipboard_mcp.server.list_clipboard_formats", return_value=[]):
+            result = await clipboard_paste()
+
+    assert "empty" in result.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `text/rtf` read support on macOS (osascript/NSPasteboard) and Windows (PowerShell/DataFormats::Rtf)
- Wayland and X11 already worked via pass-through MIME — no changes needed there
- Adds Strategy 3 to `clipboard_paste`: when HTML and plain text are both empty, tries `text/rtf` before falling through to the binary check; returns content in a labelled fenced code block, truncated at 50KB
- 6 new tests; 2 existing "unsupported MIME" tests updated to use `text/xml` (since `text/rtf` is now supported)

## Test plan

- [ ] All 165 tests pass (`uv run pytest`)
- [ ] macOS: copy rich text from Pages/Word/TextEdit → tell Claude to "read my clipboard" → response should show "rich text (RTF)" block
- [ ] Windows: copy rich text from Word/WordPad → same
- [ ] Linux (Wayland): `wl-copy --type text/rtf < sample.rtf` → same
- [ ] Large RTF (>50KB): verify truncation message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)