### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: cmeans


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` with `github: cmeans` so a ❤ Sponsor button can appear next to the Star button on the repo page.

## Manual follow-up after merge

- Enable Sponsorships in repo **Settings → Features** (UI-only toggle, can't be done from a PR).

## Test plan

- [ ] After merge + toggle, confirm the Sponsor button is visible on https://github.com/cmeans/mcp-clipboard.
- [ ] Confirm the button links to https://github.com/sponsors/cmeans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)