### PR TITLE
Fix XSS: escape cell values in _format_html

### DIFF
--- a/src/mcp_clipboard/parser.py
+++ b/src/mcp_clipboard/parser.py
@@ -8,6 +8,7 @@ as arbitrary non-tabular content (plain text, code, JSON, URLs).
 from __future__ import annotations
 
 import csv
+import html
 import io
 import json
 import re
@@ -449,11 +450,11 @@ def _format_html(rows: list[list[str]]) -> str:
     normalized = [row + [""] * (max_cols - len(row)) for row in rows]
 
     lines = ["<table>", "  <thead>"]
-    lines.append("    <tr>" + "".join(f"<th>{cell}</th>" for cell in normalized[0]) + "</tr>")
+    lines.append("    <tr>" + "".join(f"<th>{html.escape(cell)}</th>" for cell in normalized[0]) + "</tr>")
     lines.append("  </thead>")
     lines.append("  <tbody>")
     for row in normalized[1:]:
-        lines.append("    <tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>")
+        lines.append("    <tr>" + "".join(f"<td>{html.escape(cell)}</td>" for cell in row) + "</tr>")
     lines.append("  </tbody>")
     lines.append("</table>")
 


### PR DESCRIPTION
## Summary
Use `html.escape()` to sanitize cell content before interpolating into `<th>` and `<td>` tags. Prevents XSS attacks when copying malicious HTML content and outputting as HTML format.

## Security Fix
**Issue**: #15 - XSS in _format_html does not escape cell values

**Severity**: High (security-relevant correctness bug)

## Changes
- Added `import html` to parser.py
- Applied `html.escape()` to cell values in `<th>` and `<td>` tags

## Testing
Cells containing `<`, `>`, `&`, `"`, and `<script>` payloads are now safely escaped.

---
*Submitted by Backend Bounty Hunter | EVM: 0x6FCBd5d14FB296933A4f5a515933B153bA24370E*