### PR TITLE
fix: validate mime_type in clipboard_copy via _MIME_RE (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented here.
   parsing) and html (`<th>`/`<td>` counts), so a formatter that dropped
   or failed to pad the short row would be caught. Closes #71.
 
+### Fixed
+- `clipboard_copy` now validates `mime_type` against `_MIME_RE` before
+  writing to the clipboard. Previously only `clipboard_read_raw` validated;
+  invalid values like `not-a-mime` or `123/456` passed through unchecked
+  to the backend subprocess. Closes #75.
+
 ### Changed
 - `tests/test_server.py` adds an autouse fixture that resets the module
   global `cb._backend` around every test, replacing scattered manual

--- a/src/mcp_clipboard/server.py
+++ b/src/mcp_clipboard/server.py
@@ -388,6 +388,11 @@ async def clipboard_copy(
     mime_type: str = "text/plain",
 ) -> str:
     mime_type = mime_type.strip().lower()
+    if not _MIME_RE.match(mime_type):
+        return (
+            f"Invalid MIME type: {mime_type!r}. "
+            f"Expected format: type/subtype (e.g. text/plain, text/html)."
+        )
     content_bytes = len(content.encode())
     if content_bytes > _MAX_WRITE_BYTES:
         return (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2156,6 +2156,29 @@ async def test_clipboard_copy_at_limit():
     assert "characters" in result
 
 
+@pytest.mark.asyncio
+async def test_clipboard_copy_rejects_invalid_mime_type():
+    """clipboard_copy rejects MIME types that don't match _MIME_RE."""
+    result = await clipboard_copy("hello", mime_type="not-a-mime")
+    assert "Invalid MIME type" in result
+
+
+@pytest.mark.asyncio
+async def test_clipboard_copy_rejects_numeric_mime_type():
+    """clipboard_copy rejects MIME types with numeric-prefixed type/subtype."""
+    result = await clipboard_copy("hello", mime_type="123/456")
+    assert "Invalid MIME type" in result
+
+
+@pytest.mark.asyncio
+async def test_clipboard_copy_accepts_valid_typed_mime():
+    """clipboard_copy accepts valid non-text/plain MIME types."""
+    with patch("mcp_clipboard.server.write_clipboard_typed", new_callable=AsyncMock):
+        result = await clipboard_copy("hello", mime_type="text/html")
+    assert "characters" in result
+    assert "text/html" in result
+
+
 # ---------------------------------------------------------------------------
 # 25. Misc medium-priority tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #75. `clipboard_copy` lowercased `mime_type` and checked the binary-prefix list, but did not validate against `_MIME_RE`. By contrast, `clipboard_read_raw` did validate. The unvalidated value reached `wl-copy --type <mime>` / `xclip -target <mime>` on Linux backends.

Not exploitable (`asyncio.create_subprocess_exec` blocks shell injection), but a consistency gap and hygiene issue.

## Changes

- `src/mcp_clipboard/server.py`: add `_MIME_RE.match()` check after `mime_type.strip().lower()`, matching the read-path pattern.
- `tests/test_server.py`: 3 new tests:
  - `test_clipboard_copy_rejects_invalid_mime_type` -- `not-a-mime` rejected
  - `test_clipboard_copy_rejects_numeric_mime_type` -- `123/456` rejected
  - `test_clipboard_copy_accepts_valid_typed_mime` -- `text/html` works
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Test plan

- [x] `uv run pytest` -- 480 passed, 5 expected xfails
- [x] `uv run ruff check src tests` -- clean
- [x] `uv run ruff format --check src tests` -- clean
- [x] `uv run mypy src` -- clean
- [x] RED: `clipboard_copy("hello", mime_type="not-a-mime")` returned success before fix
- [x] GREEN: now returns "Invalid MIME type" error

Closes #75