### PR TITLE
fix(windows): force UTF-8 stdout in _windows_read for all text branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ All notable changes to this project will be documented here.
   record `mcp_clipboard_version` from inside an MCP session
   without depending on a shell or filesystem access.
 
+### Fixed
+- Windows: non-ASCII characters survive `clipboard_paste` and
+  `clipboard_read_raw` round-trips. Em dash (U+2014), curly quotes
+  (U+2018-U+201D), ellipsis (U+2026), and non-Latin scripts (CJK,
+  Arabic, emoji) were being transliterated to the closest ASCII
+  equivalent or substituted with `?` on the way out of PowerShell.
+  Root cause: `_windows_read` for text/plain, text/html, and
+  text/rtf invoked PowerShell without setting
+  `[Console]::OutputEncoding`, leaving stdout encoded with the
+  parent's active console code page (typically CP1252 on US-English
+  Windows). The clipboard bytes are stored correctly in UTF-16; the
+  loss happened only on the way back to Python. Fix prepends
+  `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;` to
+  every PowerShell-backed `_windows_read` branch, mirroring the
+  existing `_WINDOWS_UTF8_PREAMBLE` on the input side from #131.
+  The Windows e2e suite captured this directly: mc-103 / mc-301 /
+  mc-302 confirm the clipboard bytes round-trip byte-perfect; the
+  same input under different parent codepages produced corrupted
+  vs. clean reads in the same run (mc-002/003 vs mc-026/027/028).
+
 ## [2.6.1] - 2026-05-07
 
 ### Fixed

--- a/src/mcp_clipboard/clipboard.py
+++ b/src/mcp_clipboard/clipboard.py
@@ -427,8 +427,9 @@ async def _macos_list_formats(selection: str = "clipboard") -> list[str]:
 # every read branch eliminates the dependence on the parent's console codepage.
 # See #142 for the diagnostic chain (mc-026/027/028/102 confirmed the clipboard
 # bytes intact while mc-002/003 saw the corruption from the same code path
-# under a different parent codepage). Sibling fix to #129's input-side
-# preamble in _windows_write* (see _WINDOWS_UTF8_PREAMBLE).
+# under a different parent codepage). Sibling fix to #131's input-side preamble
+# (which closed #129) in _windows_write* (see _WINDOWS_UTF8_PREAMBLE). Also
+# closes #132, the read-direction tracker filed during #131's QA review.
 _WINDOWS_UTF8_OUTPUT_PREAMBLE = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
 
 

--- a/src/mcp_clipboard/clipboard.py
+++ b/src/mcp_clipboard/clipboard.py
@@ -417,11 +417,27 @@ async def _macos_list_formats(selection: str = "clipboard") -> list[str]:
     return result
 
 
+# PowerShell's default [Console]::OutputEncoding is the active console code
+# page (typically CP1252 / OEM ANSI on US-English Windows). When Get-Clipboard
+# returns a UTF-16 string and PowerShell pipes it to stdout for our subprocess
+# capture, that encoder best-fit-transliterates non-ASCII codepoints (em dash
+# -> hyphen, curly quote -> straight, ellipsis -> period) and substitutes
+# unmappable ones (CJK, Arabic, emoji) with U+003F. The bytes on the clipboard
+# are correct; only the way back to Python is lossy. Forcing UTF-8 stdout in
+# every read branch eliminates the dependence on the parent's console codepage.
+# See #142 for the diagnostic chain (mc-026/027/028/102 confirmed the clipboard
+# bytes intact while mc-002/003 saw the corruption from the same code path
+# under a different parent codepage). Sibling fix to #129's input-side
+# preamble in _windows_write* (see _WINDOWS_UTF8_PREAMBLE).
+_WINDOWS_UTF8_OUTPUT_PREAMBLE = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
+
+
 async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
     _reject_non_clipboard_selection(selection, "Windows")
     if mime_type == "text/html":
-        # PowerShell: Get HTML format from clipboard
         script = (
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE
+            + "Add-Type -AssemblyName System.Windows.Forms; "
             "[System.Windows.Forms.Clipboard]::GetData([System.Windows.Forms.DataFormats]::Html)"
         )
         return await _run(
@@ -429,7 +445,7 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
                 "powershell",
                 "-NoProfile",
                 "-Command",
-                f"Add-Type -AssemblyName System.Windows.Forms; {script}",
+                script,
             ],
             allow_empty_exit=False,
         )
@@ -440,14 +456,15 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
                 "powershell",
                 "-NoProfile",
                 "-Command",
-                "Get-Clipboard",
+                _WINDOWS_UTF8_OUTPUT_PREAMBLE + "Get-Clipboard",
             ],
             allow_empty_exit=False,
         )
 
     if mime_type == "text/rtf":
         script = (
-            "Add-Type -AssemblyName System.Windows.Forms; "
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE
+            + "Add-Type -AssemblyName System.Windows.Forms; "
             "$data = [System.Windows.Forms.Clipboard]::GetData("
             "[System.Windows.Forms.DataFormats]::Rtf); "
             "if ($data -eq $null) { return }; $data"
@@ -465,12 +482,10 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
     if mime_type == "image/svg+xml":
         # SVG is written via _windows_write_typed as a custom format string
         # 'image/svg+xml' on the DataObject. Reading it back uses the same
-        # format string. Output encoding matters here too: PowerShell's
-        # default OutputEncoding can mangle the UTF-8 SVG markup on the way
-        # back to Python's _run() decoder. Force UTF-8 on stdout.
+        # format string. Same UTF-8 stdout preamble as the text branches.
         script = (
-            "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
-            "Add-Type -AssemblyName System.Windows.Forms; "
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE
+            + "Add-Type -AssemblyName System.Windows.Forms; "
             "$data = [System.Windows.Forms.Clipboard]::GetData('image/svg+xml'); "
             "if ($data -eq $null) { return }; $data"
         )

--- a/src/mcp_clipboard/clipboard.py
+++ b/src/mcp_clipboard/clipboard.py
@@ -436,8 +436,7 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
     _reject_non_clipboard_selection(selection, "Windows")
     if mime_type == "text/html":
         script = (
-            _WINDOWS_UTF8_OUTPUT_PREAMBLE
-            + "Add-Type -AssemblyName System.Windows.Forms; "
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE + "Add-Type -AssemblyName System.Windows.Forms; "
             "[System.Windows.Forms.Clipboard]::GetData([System.Windows.Forms.DataFormats]::Html)"
         )
         return await _run(
@@ -463,8 +462,7 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
 
     if mime_type == "text/rtf":
         script = (
-            _WINDOWS_UTF8_OUTPUT_PREAMBLE
-            + "Add-Type -AssemblyName System.Windows.Forms; "
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE + "Add-Type -AssemblyName System.Windows.Forms; "
             "$data = [System.Windows.Forms.Clipboard]::GetData("
             "[System.Windows.Forms.DataFormats]::Rtf); "
             "if ($data -eq $null) { return }; $data"
@@ -484,8 +482,7 @@ async def _windows_read(mime_type: str, selection: str = "clipboard") -> str:
         # 'image/svg+xml' on the DataObject. Reading it back uses the same
         # format string. Same UTF-8 stdout preamble as the text branches.
         script = (
-            _WINDOWS_UTF8_OUTPUT_PREAMBLE
-            + "Add-Type -AssemblyName System.Windows.Forms; "
+            _WINDOWS_UTF8_OUTPUT_PREAMBLE + "Add-Type -AssemblyName System.Windows.Forms; "
             "$data = [System.Windows.Forms.Clipboard]::GetData('image/svg+xml'); "
             "if ($data -eq $null) { return }; $data"
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -996,6 +996,29 @@ async def test_windows_read_rtf():
     assert "Rtf" in cmd[-1]
 
 
+@pytest.mark.parametrize("mime_type", ["text/plain", "text/html", "text/rtf", "image/svg+xml"])
+@pytest.mark.asyncio
+async def test_windows_read_sets_utf8_output_encoding(mime_type):
+    """Every PowerShell-backed _windows_read branch must prepend
+    [Console]::OutputEncoding = UTF8 so non-ASCII codepoints survive the
+    return trip to Python. Without this, PowerShell's stdout encoder defaults
+    to the parent's console code page (typically CP1252 on Windows), which
+    transliterates em dash to hyphen, ellipsis to period, and substitutes
+    unmappable codepoints (CJK, Arabic, emoji) with U+003F. Regression
+    guard for #142."""
+    with patch(
+        "mcp_clipboard.clipboard._run", new_callable=AsyncMock, return_value=""
+    ) as mock_run:
+        await _windows_read(mime_type)
+
+    cmd = mock_run.call_args[0][0]
+    script = cmd[-1]
+    assert "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8" in script, (
+        f"PowerShell script for {mime_type} is missing the UTF-8 stdout preamble; "
+        f"non-ASCII codepoints will be lossy on round-trip. Script: {script!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_windows_list_formats_maps_names_to_mime():
     """_windows_list_formats maps known Windows format names to MIME types and

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1005,15 +1005,29 @@ async def test_windows_read_sets_utf8_output_encoding(mime_type):
     to the parent's console code page (typically CP1252 on Windows), which
     transliterates em dash to hyphen, ellipsis to period, and substitutes
     unmappable codepoints (CJK, Arabic, emoji) with U+003F. Regression
-    guard for #142."""
+    guard for #142 / #132. Also asserts the preamble precedes any
+    Get-Clipboard or GetData invocation: the assignment has to take effect
+    before PowerShell writes anything to stdout, so a future refactor that
+    keeps the preamble but moves it past the read call would be a silent
+    regression."""
     with patch("mcp_clipboard.clipboard._run", new_callable=AsyncMock, return_value="") as mock_run:
         await _windows_read(mime_type)
 
     cmd = mock_run.call_args[0][0]
     script = cmd[-1]
-    assert "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8" in script, (
+    preamble = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8"
+    assert preamble in script, (
         f"PowerShell script for {mime_type} is missing the UTF-8 stdout preamble; "
         f"non-ASCII codepoints will be lossy on round-trip. Script: {script!r}"
+    )
+    preamble_pos = script.index(preamble)
+    # text/plain uses Get-Clipboard; the other branches use Clipboard::GetData.
+    read_marker = "Get-Clipboard" if mime_type == "text/plain" else "Clipboard]::GetData"
+    read_pos = script.index(read_marker)
+    assert preamble_pos < read_pos, (
+        f"PowerShell script for {mime_type} has the UTF-8 preamble after the "
+        f"{read_marker} call; the encoding assignment must take effect before "
+        f"any clipboard read writes to stdout. Script: {script!r}"
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1006,9 +1006,7 @@ async def test_windows_read_sets_utf8_output_encoding(mime_type):
     transliterates em dash to hyphen, ellipsis to period, and substitutes
     unmappable codepoints (CJK, Arabic, emoji) with U+003F. Regression
     guard for #142."""
-    with patch(
-        "mcp_clipboard.clipboard._run", new_callable=AsyncMock, return_value=""
-    ) as mock_run:
+    with patch("mcp_clipboard.clipboard._run", new_callable=AsyncMock, return_value="") as mock_run:
         await _windows_read(mime_type)
 
     cmd = mock_run.call_args[0][0]


### PR DESCRIPTION
## Summary

Closes #142. Closes #132.

PowerShell's `[Console]::OutputEncoding` defaults to the parent's active console code page (typically CP1252 on US-English Windows). When `_windows_read` for text/plain, text/html, or text/rtf piped `Get-Clipboard` output back to Python, non-ASCII codepoints were transliterated (em dash → hyphen, curly → straight, ellipsis → period) or `?`-substituted (CJK, Arabic, emoji). The clipboard bytes are stored correctly in UTF-16; the loss only happens on the read-back trip.

The SVG branch already had `[Console]::OutputEncoding = UTF8` (added in #138's read fix). Text/plain, text/html, and text/rtf did not. This PR adds the preamble to all four branches via a shared `_WINDOWS_UTF8_OUTPUT_PREAMBLE` constant, mirroring the existing input-side `_WINDOWS_UTF8_PREAMBLE` introduced in #131 to address #129.

#132 was filed during #131's QA review specifically as the read-direction follow-up tracker. Its suggested approach asked for: (1) reproduce on QEMU, (2) add the symmetric `OutputEncoding = UTF8` preamble to `_windows_read` and any sibling read scripts, (3) add unit tests asserting the preamble is present and precedes any `Get-Clipboard` invocation. This PR delivers all three.

Bug class is identical in shape to #131; this is the same fix on the output leg.

## Diagnostic chain

The Windows e2e test suite captured this directly. Run-index `048f8f0a-7cc4-4e50-9748-f17893abf471` (`mcp-clipboard-windows-e2e-run-claude-code-2026-05-09T17:29:15Z`):

- **mc-103** direct `PowerShell::Clipboard::GetData('image/svg+xml')` returned 116 bytes ending `73 76 67 3E` (`svg>`, no trailing CRLF) — clipboard bytes are intact.
- **mc-301 / mc-302** SVG byte-perfect round-trips at 200, 500, and 1000-byte payloads via direct PowerShell read with UTF-8 OutputEncoding.
- **mc-026 / mc-027 / mc-028** PASSED with em dash, curly quotes, ellipsis, CJK, and Arabic intact when the MCP server's parent process happened to have a UTF-8-aware console codepage.
- **mc-002 / mc-003** FAILED with the *same* input bytes when the MCP server's parent had CP1252. Same code path, different parent environment, opposite outcomes — proof that the storage is correct and only the read-side encoding varies.
- **mc-102** direct PowerShell with explicit `OutputEncoding = UTF8` returned `68 65 6c 6c 6f` (`hello`) byte-perfect.

Conclusion: the clipboard write and storage are correct; the only variable is whether the read script forces UTF-8 stdout. With the explicit preamble, the parent codepage no longer matters.

## What's in

- `src/mcp_clipboard/clipboard.py` — adds `_WINDOWS_UTF8_OUTPUT_PREAMBLE` constant, prepends it to all four `_windows_read` PowerShell-backed branches.
- `tests/test_server.py` — parameterized regression test asserting every branch (text/plain, text/html, text/rtf, image/svg+xml) emits the preamble AND that the preamble precedes the `Get-Clipboard` / `Clipboard::GetData` call (so a future refactor can't keep the preamble but move it past the read).
- `CHANGELOG.md` — entry under `### Fixed` in `[Unreleased]`.

## Test plan
- [x] `uv run pytest` — full local suite (624 passed locally on this branch).
- [ ] Re-run the Windows e2e suite on the QEMU guest under v2.6.2 (post-merge): mc-002 and mc-003 should PASS regardless of the parent process's console codepage; mc-026 / mc-027 / mc-028 / mc-102 / mc-103 / mc-301 / mc-302 should remain PASS.
- [ ] Confirm em dash + curly quotes + ellipsis round-trip in CD on Windows (the original user-facing scenario from #129's lineage).

## Related
- Sibling to #131 (`_WINDOWS_UTF8_PREAMBLE` on stdin)
- Diagnostic complement to #138 (which fixed the SVG branch's stdout encoding while leaving the text branches unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)